### PR TITLE
unload modules imported by pytest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Fix pytest **Module already imported so cannot be rewritten** warning when the package being linted was used by pytest/conftest already (#10)
 
 ## [1.0.1] - 2021-03-03
 ### Added

--- a/pylint_pytest/checkers/fixture.py
+++ b/pylint_pytest/checkers/fixture.py
@@ -72,13 +72,25 @@ class FixtureChecker(BasePytestChecker):
                 # run pytest session with customized plugin to collect fixtures
                 fixture_collector = FixtureCollector()
 
+                # save and remove modules imported by pytest to prevent pytest warning during fixture collection:
+                # <PytestAssertRewriteWarning: Module already imported so cannot be rewritten>
+                sys_mods = set(sys.modules.keys())
+
                 # save and restore sys.path to prevent pytest.main from altering it
                 sys_path = sys.path.copy()
+
                 pytest.main(
                     [node.file, '--fixtures', '--collect-only'],
                     plugins=[fixture_collector],
                 )
+
+                # restore sys.path
                 sys.path = sys_path
+
+                # unload modules imported by pytest.main
+                for module in set(sys.modules.keys()) - sys_mods:
+                    del sys.modules[module]
+
                 FixtureChecker._pytest_fixtures = fixture_collector.fixtures
         finally:
             # restore output devices


### PR DESCRIPTION
For #10 

When running `pytest.main`, `pytest` will import all the packages it needs including the ones specified in cli and `conftest.py`. However, since we're running multiple `pytest` sessions in one lint run, it'll complain if a package was already imported: https://github.com/pytest-dev/pytest/blob/6.2.2/src/_pytest/assertion/rewrite.py#L254-L259

This PR is a hacky way to unload the pytest-imported module(s) after running `pytest.main` to restore the state. 