### PR TITLE
#13 fix regression from manually manipulating sys.modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+## Fixed
+- Fix #13 regression caused by mangling `sys.modules`
 
 ## [1.0.2] - 2021-03-10
 ### Fixed

--- a/pylint_pytest/checkers/fixture.py
+++ b/pylint_pytest/checkers/fixture.py
@@ -72,24 +72,19 @@ class FixtureChecker(BasePytestChecker):
                 # run pytest session with customized plugin to collect fixtures
                 fixture_collector = FixtureCollector()
 
-                # save and remove modules imported by pytest to prevent pytest warning during fixture collection:
-                # <PytestAssertRewriteWarning: Module already imported so cannot be rewritten>
-                sys_mods = set(sys.modules.keys())
-
                 # save and restore sys.path to prevent pytest.main from altering it
                 sys_path = sys.path.copy()
 
                 pytest.main(
-                    [node.file, '--fixtures', '--collect-only'],
+                    [
+                        node.file, '--fixtures', '--collect-only',
+                        '--pythonwarnings=ignore:Module already imported:pytest.PytestWarning',
+                    ],
                     plugins=[fixture_collector],
                 )
 
                 # restore sys.path
                 sys.path = sys_path
-
-                # unload modules imported by pytest.main
-                for module in set(sys.modules.keys()) - sys_mods:
-                    del sys.modules[module]
 
                 FixtureChecker._pytest_fixtures = fixture_collector.fixtures
         finally:

--- a/tests/base_tester.py
+++ b/tests/base_tester.py
@@ -1,5 +1,7 @@
 import sys
 import os
+from pprint import pprint
+
 import astroid
 from pylint.testutils import UnittestLinter
 try:
@@ -45,6 +47,7 @@ class BasePytestTester(object):
             if message.msg_id == msg_id:
                 matched_count += 1
 
+        pprint(self.MESSAGES)
         assert matched_count == msg_count, f'expecting {msg_count}, actual {matched_count}'
 
     def setup_method(self):


### PR DESCRIPTION
Using pytest `--pythonwarnings=ignore:Module already imported:pytest.PytestWarning` when collecting fixtures instead of manually mangling `sys.modules`. Apparently the modules were loaded in memory anyway and there's no clean way for Python to unload a module completely especially when they're not directly imported from the current module.

Using the said pytest option might have side effects that if a module/plugin loaded by pytest has the same name of another module being linted. Not sure how common that approach is in the field and will revisit this part if it's causing severe issues.