### PR TITLE
🐛 Ignore collection failures in non-tests

### DIFF
--- a/pylint_pytest/checkers/fixture.py
+++ b/pylint_pytest/checkers/fixture.py
@@ -61,7 +61,7 @@ class FixtureChecker(BasePytestChecker):
         'F6401': (
             (
                 'pylint-pytest plugin cannot enumerate and collect pytest fixtures. '
-                'Please run `pytest --fixtures --collect-only path/to/current/module.py` and resolve any potential syntax error or package dependency issues'
+                'Please run `pytest --fixtures --collect-only %s` and resolve any potential syntax error or package dependency issues'
             ),
             'cannot-enumerate-pytest-fixtures',
             'Used when pylint-pytest has been unable to enumerate and collect pytest fixtures.',
@@ -135,8 +135,22 @@ class FixtureChecker(BasePytestChecker):
 
                 FixtureChecker._pytest_fixtures = fixture_collector.fixtures
 
-                if (ret != pytest.ExitCode.OK or fixture_collector.errors) and is_test_module:
-                    self.add_message('cannot-enumerate-pytest-fixtures', node=node)
+                legitimate_failure_paths = set(
+                    collection_report.nodeid
+                    for collection_report in fixture_collector.errors
+                    if any(
+                        fnmatch.fnmatch(
+                            Path(collection_report.nodeid).name, pattern,
+                        )
+                        for pattern in FILE_NAME_PATTERNS
+                    )
+                )
+                if (ret != pytest.ExitCode.OK or legitimate_failure_paths) and is_test_module:
+                    self.add_message(
+                        'cannot-enumerate-pytest-fixtures',
+                        args=' '.join(legitimate_failure_paths | {node.file}),
+                        node=node,
+                    )
         finally:
             # restore output devices
             sys.stdout, sys.stderr = stdout, stderr


### PR DESCRIPTION
This change applies the pre-existing patterns to identify if the files with collection problems are tests. It is then used to eliminate the false-positives of F6401 (cannot-enumerate-pytest-fixtures).

As a side effect, this patch also includes precise file paths that may be used to reproduce the problem.

Fixes #20
Fixes #21